### PR TITLE
删除isEqualToString判断改用isKindOfClass

### DIFF
--- a/HXPhotoPicker/Category/UIViewController+HXExtension.m
+++ b/HXPhotoPicker/Category/UIViewController+HXExtension.m
@@ -244,7 +244,7 @@
 }
 
 - (HXCustomNavigationController *)hx_customNavigationController {
-    if ([NSStringFromClass([self.navigationController class]) isEqualToString:@"HXCustomNavigationController"]) {
+    if (self.navigationController && [self.navigationController isKindOfClass:HXCustomNavigationController.class]) {
         return (HXCustomNavigationController *)self.navigationController;
     }
     return nil;


### PR DESCRIPTION
如果用isEqualToString:@"HXCustomNavigationController"则没法继承HXCustomNavigationController，改用isKindOfClass判断才可以继承。