### PR TITLE
修复:视频拍满60秒,没有显示重拍按钮

### DIFF
--- a/HXPhotoPicker/Controller/HXCustomCameraViewController.m
+++ b/HXPhotoPicker/Controller/HXCustomCameraViewController.m
@@ -804,7 +804,7 @@ CLLocationManagerDelegate
         _bottomView.endTranscribe = ^(BOOL isAnimation) {
             if (![weakSelf.cameraController isRecording]) {
                 [weakSelf stopTimer];
-                weakSelf.cancelBtn.selected = NO;
+                weakSelf.cancelBtn.selected = YES;
                 weakSelf.cancelBtn.hx_w = 50;
                 weakSelf.changeCameraBtn.hidden = NO;
             }else {


### PR DESCRIPTION
修复:长按拍视频时,拍满60秒,没有重拍按钮,没法退出.